### PR TITLE
GetWants need to normalize by the sampling window.

### DIFF
--- a/go/ratelimiter/adaptive_ratelimiter.go
+++ b/go/ratelimiter/adaptive_ratelimiter.go
@@ -152,7 +152,7 @@ func (e *entries) GetWants(window time.Duration) float64 {
 		sum += frequency[i] * (n - i)
 	}
 
-	return float64(sum) / float64(len(e.times)*(len(e.times)+1)/2)
+	return float64(sum) / float64(int(window.Seconds())*(int(window.Seconds())+1)/2)
 }
 
 // Wait records entry time and blocks until the goroutine is released.


### PR DESCRIPTION
There is currently a bug where GetWants normalize by the number of event instead of the sampling window length.